### PR TITLE
Parallel SGD federated learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ turned on.
 ipfs daemon --enable-pubsub-experiment
 ```
 
+Make sure you have installed all dependencies
+
+```sh
+python setup.py install
+```
+
+You also must have keras installed.
+
 You can then run the worker daemon
 ```sh
 python3.6 ipfs_grid_worker_daemon.py
@@ -43,3 +51,27 @@ jupyter notebook
 
 navigate to `notebooks/pubsub/` and open `Keras Grid Client and Worker.ipynb` and
 follow along in that notebook.
+
+# Troubleshooting
+
+### Connect Error
+
+If you see this connect error `ERROR: could not connect to IPFS.  Is your daemon running with pubsub support at 127.0.0.1 on port 5001` make sure you run the following command:
+
+```
+ipfs daemon --enable-pubsub-experiment
+```
+
+### Trouble Running Experiment
+
+If you have any troubles running an experiment such as the other peers not learning about your jobs make sure you're connected to the peer. You can check if you're connected to the peer by running:
+
+```
+ipfs pubsub peers | grep <ipfs address>
+```
+
+And then to connect to the peer if you're not connected:
+
+`ipfs swarm connect <ipfs_address>`
+
+The swarm connect IPFS address should look something like this `/p2p-circuit/ipfs/QmXbV8HZwKYkkWAAZr1aYT3nRMCUnpp68KaxP3vccirUc8`. And can be found in the output of the daemon when you start it.

--- a/grid/grid.py
+++ b/grid/grid.py
@@ -1,0 +1,240 @@
+from . import ipfsapi
+import base64
+import random
+import keras
+import json
+import numpy as np
+import torch
+from torch.autograd import Variable
+import sys
+from colorama import Fore, Back, Style
+
+"""
+TODO: modify Client to store the source code for the model in IPFS. 
+            (think through logistics; introduces hurdles for packaging model source code)
+TODO: figure out a convenient way to make robust training procedure for torch -- will probably want to use ignite for this
+"""
+=======
+
+class Grid(object):
+
+    def __init__(self, ipfs_addr='127.0.0.1', port=5001):
+
+        try:
+            self.api = ipfsapi.connect(ipfs_addr, port)
+        except:
+            print(f'\n{Fore.RED}ERROR: {Style.RESET_ALL}could not connect to IPFS.  Is your daemon running with pubsub support at {ipfs_addr} on port {port}')
+            sys.exit()
+
+        self.encoded_id = self.get_encoded_id()
+        self.id = self.api.config_show()['Identity']['PeerID']
+
+    def get_encoded_id(self):
+
+        """Currently a workaround because we can't figure out how to decode the 'from'
+        side of messages sent across the wire. However, we can check to see if two messages
+        are equal. Thus, by sending a random message to ourselves we can figure out what
+        our own encoded id is. TODO: figure out how to decode it."""
+
+        rand_channel = random.randint(0,1000000)
+        try:
+            temp_channel = self.api.pubsub_sub(topic=rand_channel,stream=True)
+        except:
+            print(f'\n{Fore.RED}ERROR: {Style.RESET_ALL}could not connect to IPFS PUBSUB.  Did you run the daemon with {Fore.GREEN}--enable-pubsub-experiment{Style.RESET_ALL} ?')
+            sys.exit()
+
+        secret = random.randint(0,1000000)
+        self.api.pubsub_pub(topic=rand_channel,payload="id:" + str(secret))
+
+        for encoded in temp_channel:
+
+            # decode message
+            decoded = self.decode_message(encoded)
+
+            if(decoded is not None):
+                if(str(decoded['data'].split(":")[-1]) == str(secret)):
+                    return str(decoded['from'])
+
+    def decode_message(self,encoded):
+        if('from' in encoded):
+            decoded = {}
+            decoded['from'] = base64.standard_b64decode(encoded['from'])
+            decoded['data'] = base64.standard_b64decode(encoded['data']).decode('ascii')
+            decoded['seqno'] = base64.standard_b64decode(encoded['seqno'])
+            decoded['topicIDs'] = encoded['topicIDs']
+            decoded['encoded'] = encoded
+            return decoded
+        else:
+            return None
+
+    def serialize_keras_model(self,model):
+        model.save('temp_model.h5')
+        with open('temp_model.h5','rb') as f:
+            model_bin = f.read()
+        return model_bin
+
+    def deserialize_keras_model(self,model_bin):
+        with open('temp_model2.h5','wb') as g:
+            g.write(model_bin)
+        model = keras.models.load_model('temp_model2.h5')
+        return model
+
+    def serialize_torch_model(self, model, **kwargs):
+        """
+        kwargs are the arguments needed to instantiate the model
+        """
+        state = {'state_dict':model.state_dict(), 'kwargs':kwargs}
+        torch.save(state, 'temp_model.pth.tar')
+        with open('temp_model.pth.tar', 'rb') as f:
+            model_bin = f.read()
+        return model_bin
+
+    def deserialize_torch_model(self, model_bin, model_class, **kwargs):
+        """
+        model_class is needed since PyTorch uses pickle for serialization
+            see https://discuss.pytorch.org/t/loading-pytorch-model-without-a-code/12469/2 for details
+        kwargs are the arguments needed to instantiate the model from model_class
+        """
+        with open('temp_model2.pth.tar', 'wb') as g:
+            g.write(model_bin)
+        state = torch.load()
+        model = model_class(**state['kwargs'])
+        model.load_state_dict(state['state_dict'])
+        return model
+
+    def serialize_numpy(self, tensor):
+        return json.dumps(tensor.tolist()) # nested lists with same data, indices
+
+    def deserialize_numpy(self,json_array):
+        return np.array(json.loads(json_array)).astype('float')
+
+    def publish(self,channel,dict_message):
+        self.api.pubsub_pub(topic=channel,payload=json.dumps(dict_message))
+
+    
+    # TODO: framework = 'torch'
+    def generate_fit_spec(self, model,input,target,valid_input=None,valid_target=None,batch_size=1,epochs=1,log_interval=1, framework = 'keras', model_class = None):
+
+        model_bin = self.serialize_keras_model(model)
+        model_addr = self.api.add_bytes(model_bin)
+        model_cls = self.api.add_bytes(model_class)
+
+        train_input = self.serialize_numpy(input)
+        train_target = self.serialize_numpy(target)
+
+        if(valid_input is None):
+            valid_input = self.serialize_numpy(input)
+        else:
+            valid_input = self.serialize_numpy(valid_input)
+
+        if(valid_target is None):
+            valid_target = self.serialize_numpy(target)
+        else:
+            valid_target = self.serialize_numpy(valid_target)
+
+        datasets = [train_input,train_target,valid_input,valid_target]
+        data_json = json.dumps(datasets)
+        data_addr = self.api.add_str(data_json)
+
+        spec = {}
+        spec['model_addr'] = model_addr
+        spec['data_addr'] = data_addr
+        spec['batch_size'] = batch_size
+        spec['epochs'] = epochs
+        spec['log_interval'] = log_interval
+        spec['framework'] = framework
+        spec['train_channel'] = 'openmined_train_'+str(model_addr)
+        return spec
+
+    def listen_to_channel(self,handle_message,channel):
+        new_models = self.api.pubsub_sub(topic=channel,stream=True)
+
+
+        for m in new_models:
+            message = self.decode_message(m)
+            if(message is not None):
+                out = handle_message(message)
+                if(out is not None):
+                    return out
+
+
+    # TODO: torch
+    def keras2ipfs(self,model):
+        return self.api.add_bytes(self.serialize_keras_model(model))
+    
+    #TODO: torch
+    def ipfs2keras(self,model_addr):
+        model_bin = self.api.cat(model_addr)
+        return self.deserialize_keras_model(model_bin)
+    
+    # TODO: torch
+    def receive_model(self,message, verbose=True):
+        msg = json.loads(message['data'])
+        if(msg is not None):
+            if(msg['type'] == 'transact'):
+                return self.ipfs2keras(msg['model_addr']),msg
+            elif(msg['type'] == 'log'):
+                if(verbose):
+                    output = "Worker:" + msg['worker_id'][-5:]
+                    output += " - Epoch " + str(msg['epoch_id']) + " of " + str(msg['num_epochs'])
+                    output += " - Valid Loss: " + str(msg['eval_loss'])[0:8]
+                    print(output)
+
+    
+    # TODO: torch
+    def fit_worker(self,message):
+
+        decoded = json.loads(message['data'])
+
+        if(decoded['framework'] == 'keras'):
+
+            model = self.ipfs2keras(decoded['model_addr'])
+
+            try:
+                np_strings = json.loads(self.api.cat(decoded['data_addr']))
+            except:
+                raise NotImplementedError, "The IPFS API only supports Python 3.6. Please modify your environment."
+
+            input,target,valid_input,valid_target = list(map(lambda x:self.deserialize_numpy(x),np_strings))
+
+            for e in range(0,decoded['epochs'],decoded['log_interval']):
+                model.fit(input, target, batch_size=decoded['batch_size'], epochs=decoded['log_interval'], verbose=0)
+                eval_loss = model.evaluate(valid_input,valid_target,verbose=0)
+                spec = {}
+                spec['type'] = 'log'
+                spec['eval_loss'] = eval_loss
+                spec['epoch_id'] = e
+                spec['num_epochs'] = decoded['epochs']
+                spec['parent_model'] = decoded['model_addr']
+                spec['worker_id'] = self.id
+                self.publish(channel=decoded['train_channel'],dict_message=spec)
+
+            spec = {}
+            spec['type'] = 'transact'
+            spec['model_addr'] = self.keras2ipfs(model)
+            spec['eval_loss'] = eval_loss
+            spec['parent_model'] = decoded['model_addr']
+            spec['worker_id'] = self.id
+            self.publish(channel=decoded['train_channel'],dict_message=spec)
+
+            output = "Model:" + spec['parent_model'][-5:]
+            output += " - Epochs " + str(decoded['epochs'])
+            output += " - Valid Loss: " + str(spec['eval_loss'])[0:8]
+            print(output)
+        
+        else:
+            raise NotImplementedError, "Only compatible with Keras at the moment"
+
+
+    def fit(self, model,input,target,valid_input=None,valid_target=None,batch_size=1,epochs=1,log_interval=1,message_handler=None):
+
+        if(message_handler is None):
+            message_handler = self.receive_model
+        spec = self.generate_fit_spec(model,input,target,valid_input,valid_target,batch_size,epochs,log_interval)
+        self.publish('openmined',spec)
+
+        trained = self.listen_to_channel(message_handler,spec['train_channel'])
+        return trained
+
+    def work(self):
+        self.listen_to_channel(self.fit_worker,'openmined')

--- a/grid/lib/utils.py
+++ b/grid/lib/utils.py
@@ -3,6 +3,8 @@ from grid import ipfsapi
 import keras
 import os
 import json
+from colorama import Fore, Back, Style
+import sys
 
 
 def get_ipfs_api(ipfs_addr='127.0.0.1', port=5001):

--- a/grid/pubsub/base.py
+++ b/grid/pubsub/base.py
@@ -107,7 +107,6 @@ class PubSub(object):
         torch.save(state, 'temp_model.pth.tar')
         with open('temp_model.pth.tar', 'rb') as f:
             model_bin = f.read()
-            f.close()
         return model_bin
 
     def deserialize_torch_model(self, model_bin, model_class, **kwargs):
@@ -118,7 +117,6 @@ class PubSub(object):
         """
         with open('temp_model2.pth.tar', 'wb') as g:
             g.write(model_bin)
-            g.close()
         state = torch.load()
         model = model_class(**state['kwargs'])
         model.load_state_dict(state['state_dict'])
@@ -130,7 +128,7 @@ class PubSub(object):
     Methods for Grid tree down here
     """
 
-    def send_best_model(self, name, model_addr):
+    def send_model(self, name, model_addr):
         task = utils.load_task(name)
 
         update = {
@@ -144,13 +142,13 @@ class PubSub(object):
         update_addr = self.api.add_json(update)
         self.publish(channels.add_model(name), update_addr)
 
-        print("SENDING BEST MODEL!!!!")
+        print("SENDING MODEL!!!!")
 
     def add_model(self, name, model, parent=None):
         """
         Propose a model as a solution to a task.
 
-        Task  - The name of the task.  e.g. MNIST
+        parent  - The name of the task.  e.g. MNIST
         model - A keras model. Down the road we should support more frameworks.
         """
         task = utils.load_task(name)

--- a/grid/pubsub/worker.py
+++ b/grid/pubsub/worker.py
@@ -48,6 +48,13 @@ TODO: figure out a convenient way to make robust training procedure for torch
 
 class Worker(base.PubSub):
 
+    def anchor(self):
+        """
+        Use as anchor node for faster initial IPFS connections.
+        """
+        self.listen_to_channel(channels.openmined)
+
+
     def train_meta(self, message):
         decoded = json.loads(message['data'])
         if 'op_code' not in decoded:
@@ -135,7 +142,7 @@ class Worker(base.PubSub):
 
         my_best = utils.best_model_for_task(task)
         if my_best is not None:
-            self.send_best_model(task, my_best)
+            self.send_model(task, my_best)
 
     def list_tasks(self, message):
         fr = base58.encode(message['from'])
@@ -224,7 +231,6 @@ class Worker(base.PubSub):
         else:
             print("Can't train your own model so soon!!!!!")
 
-
     def discovered_tasks(self, tasks):
         print(f'{Fore.WHITE}{Back.BLACK} TASKS {Style.RESET_ALL}')
         print(f'From\t\t\t\tName\t\t\t\tAddress')
@@ -248,3 +254,14 @@ class Worker(base.PubSub):
                 utils.store_task(name, addr)
             else:
                 print(f"DON'T HAVE DATA FOR {name} DATA DIRECTORY: {data_dir}")
+
+class FederatedWorker(base.PubSub):
+    """
+    Data parallel federated learning worker.
+    """
+    def __init__(self, sync = True):
+        if not sync:
+            raise NotImplementedError, 'Only synchronous SGD right now.'
+
+    def work(self):
+        raise NotImplementedError

--- a/notebooks/pubsub/Federated.ipynb
+++ b/notebooks/pubsub/Federated.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jasonmancuso/anaconda/envs/openmined/lib/python3.6/site-packages/h5py-2.7.1-py3.6-macosx-10.7-x86_64.egg/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
+      "  from ._conv import register_converters as _register_converters\n",
+      "Using TensorFlow backend.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A local file was found, but it seems to be incomplete or outdated because the auto file hash does not match the original value of 8a61469f7ea1b51cbae51d4f78837e45 so we will re-download the data.\n",
+      "Downloading data from https://s3.amazonaws.com/img-datasets/mnist.npz\n",
+      "11493376/11490434 [==============================] - 1s 0us/step\n"
+     ]
+    }
+   ],
+   "source": [
+    "from keras.datasets import mnist\n",
+    "(x_train, y_train), (x_test, y_test) = mnist.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:openmined]",
+   "language": "python",
+   "name": "conda-env-openmined-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Brief outline of the goal of this feature:
I'm trying to make a version of federated learning that uses parallel SGD for training shared models.  I'm thinking there's a master node with the target model at all times, and this target model gets updated by gradients coming from worker nodes.  With the synchronous version, it averages the gradients, while with asynchronous, it updates the master model as it receives the gradients from each worker.  Every so often, it publishes the current version of the model, and the workers use that model to create new gradients.  There are a lot of ways to extend this, but I'm shooting for simple synchronous/asynchronous training in this way for right now.  This will all be running on PubSub, and we want to have the gradients published be picked up by the Trillian app that the ETHDenver guys are working on (which essentially just means using the `send_model` method already in `base.PubSub` as far as I can tell).

Currently, just started it as a subclass of `base.PubSub` to make a federated worker.  I'm guessing most of the changes will need to come from the client side.  The goal will eventually be to either merge this with compute mode and tree mode under the same Client/Worker classes, or to have wrappers/subclasses of base Client/Worker classes for each mode (I'm in favor of the latter for the sake of modularity).