### PR TITLE
adding torch in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ethereum
 tensorflow
 colorama
 keras
+torch
 h5py
 mnemonic
 python-bitcoinlib


### PR DESCRIPTION
While running
`from grid.pubsub.worker import Worker`

worker.py imports base class
`from . import base`

While base imports torch.