### PR TITLE
Add import for missing modules compute.py

### DIFF
--- a/grid/pubsub/workers/compute.py
+++ b/grid/pubsub/workers/compute.py
@@ -1,8 +1,8 @@
 from . import base_worker
-from ...lib import strings
+from ...lib import strings, utils, output_pipe
 from .. import channels
 import json
-
+import threading
 class GridCompute(base_worker.GridWorker):
 
     """
@@ -86,7 +86,7 @@ class GridCompute(base_worker.GridWorker):
         # Output pipe is a keras callback
         # https://keras.io/callbacks/
         # See `OutputPipe` for more info.
-        self.learner_callback = OutputPipe(
+        self.learner_callback = output_pipe.OutputPipe(
             id=self.id,
             publisher=self.publish,
             channel=train_channel,


### PR DESCRIPTION
Some imports were missing in the `compute.py` file resulting in an error at the worker when trying to do go through `Keras Grid Client and Worker.ipynb`.