### PR TITLE
Add 'torch' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch
 numpy
 jupyter
 requests


### PR DESCRIPTION
Torch is required to run the worker, but it's not listed in the
`requirements.txt`!