### PR TITLE
Remove ethereum dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ torch
 numpy
 jupyter
 requests
-ethereum
 tensorflow
 colorama
 keras

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = read('requirements.txt').split()
 platform = platform.system()
-if platform == 'Windows':
-    requirements.remove('ethereum')
 
 setup(
     name="grid",
@@ -57,7 +54,7 @@ setup(
     classifiers=[
         "Development Status :: 1 - Alpha",
     ],
-    install_requires=requirements,
+    install_requires=read('requirements.txt').split(),
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-flake8'],
     cmdclass={


### PR DESCRIPTION
Ethereum is no longer a dependency for running grid and was breaking
installation due to one of it's dependencies introducing a build bug.

Therefore, we decided to remove it entirely!