### PR TITLE
Fix ubuntu_installation.sh

### DIFF
--- a/install_scripts/ubuntu_installation.sh
+++ b/install_scripts/ubuntu_installation.sh
@@ -1,13 +1,3 @@
-
-wget https://repo.continuum.io/archive/Anaconda3-5.1.0-Linux-x86_64.sh
-
-bash Anaconda3-5.1.0-Linux-x86_64.sh
-rm Anaconda3-5.1.0-Linux-x86_64.sh
-
-/home/ubuntu/anaconda3/bin/conda create -n py36 python=3.6 anaconda -y
-source activate py36
-/home/ubuntu/anaconda3/bin/conda install pytorch-cpu torchvision -c pytorch
-
 sudo apt-get update
 sudo apt-get install libssl-dev  -y
 


### PR DESCRIPTION
Removed Anaconda install from ubuntu install script.  This now means you have to have torch installed before running `python setup.py install`.