### PR TITLE
Prepend node type to IPFS Peer ID

### DIFF
--- a/grid/base.py
+++ b/grid/base.py
@@ -12,15 +12,12 @@ from bitcoin import base58
 
 
 class PubSub(object):
-    def __init__(self, mode, ipfs_addr='127.0.0.1', port=5001):
-        self.api = utils.get_ipfs_api()
-        peer_id = self.api.config_show()['Identity']['PeerID']
-        self.id = f'{peer_id}'
-        # switch to this to make local develop work
-        # self.id = f'{mode}:{peer_id}'
+    def __init__(self, node_type='client', ipfs_addr='127.0.0.1', port=5001):
+        self.node_type = node_type
+        self.api = utils.get_ipfs_api(self.node_type)
+        self.id = utils.get_id(self.node_type, self.api)
         self.subscribed_list = []
 
-    
     """
     Grid Tree Implementation
 
@@ -57,7 +54,7 @@ class PubSub(object):
         else:
             p = parent
 
-        model_addr = keras_utils.keras2ipfs(model)
+        model_addr = keras_utils.keras2ipfs(self.api, model)
 
         update = {
             'name': name,

--- a/grid/base.py
+++ b/grid/base.py
@@ -1,15 +1,5 @@
 from grid.lib import utils, keras_utils
 from grid import channels
-import base64
-import json
-import numpy as np
-from threading import Thread
-import torch
-import time
-import sys
-from colorama import Fore, Back, Style
-from bitcoin import base58
-
 
 class PubSub(object):
     def __init__(self, node_type='client', ipfs_addr='127.0.0.1', port=5001):

--- a/grid/clients/base.py
+++ b/grid/clients/base.py
@@ -15,9 +15,8 @@ import ipywidgets as widgets
 class BaseClient(base_worker.GridWorker):
 
     def __init__(self,min_om_nodes=1,known_workers=list(),include_github_known_workers=True,verbose=True):
-        super().__init__()
+        super().__init__('client')
         self.progress = {}
-
         self.services = {}
 
         self.services['listen_for_openmined_nodes'] = ListenForOpenMinedNodesService(self,min_om_nodes,known_workers,include_github_known_workers)

--- a/grid/clients/keras.py
+++ b/grid/clients/keras.py
@@ -1,6 +1,8 @@
 from . import base
 from ..lib import utils
 from ..lib import coinbase_helper
+from .. import channels
+import ipywidgets as widgets
 import json
 import random
 
@@ -102,14 +104,14 @@ class KerasClient(base.BaseClient):
         return spec
 
     def load_model(self, addr):
-        return keras_utils.ipfs2keras(addr)
+        return keras_utils.ipfs2keras(self.api, addr)
 
     def receive_model(self, message, verbose=True):
         msg = json.loads(message['data'])
 
         if(msg is not None):
             if(msg['type'] == 'transact'):
-                return keras_utils.ipfs2keras(msg['model_addr']), msg
+                return keras_utils.ipfs2keras(self.api, msg['model_addr']), msg
             elif(msg['type'] == 'log'):
                 if(verbose):
                     output = "Worker:" + msg['worker_id'][-5:]
@@ -147,9 +149,6 @@ class KerasClient(base.BaseClient):
         hbox = widgets.HBox([widgets.Label(model_addr)])
         self.show_models.children += (hbox,)
 
-    def load_model(self, addr):
-        return keras_utils.ipfs2keras(addr)
-
     def send_model(self, name, model_addr):
         task = utils.load_task(name)
 
@@ -179,7 +178,7 @@ class KerasClient(base.BaseClient):
         else:
             p = parent
 
-        model_addr = keras_utils.keras2ipfs(model)
+        model_addr = keras_utils.keras2ipfs(self.api, model)
 
         update = {
             'name': name,

--- a/grid/lib/keras_utils.py
+++ b/grid/lib/keras_utils.py
@@ -7,14 +7,11 @@ from . import utils
 import keras
 
 
-def keras2ipfs(model):
-    return utils.get_ipfs_api().add_bytes(serialize_keras_model(model))
+def keras2ipfs(api, model):
+    return api.add_bytes(serialize_keras_model(model))
 
-
-def ipfs2keras(model_addr):
-    model_bin = utils.get_ipfs_api().cat(model_addr)
-    return deserialize_keras_model(model_bin)
-
+def ipfs2keras(api, model_addr):
+    return deserialize_keras_model(api.cat(model_addr))
 
 def serialize_keras_model(model):
     lock = FileLock('temp_model.h5.lock')
@@ -36,18 +33,18 @@ def deserialize_keras_model(model_bin):
         return model
 
 
-def save_best_keras_model_for_task(task, model):
+def save_best_keras_model_for_task(api, task, model):
     utils.ensure_exists(f'{Path.home()}/.openmined/models.json', {})
     with open(f"{Path.home()}/.openmined/models.json", "r") as model_file:
         models = json.loads(model_file.read())
 
-    models[task] = keras2ipfs(model)
+    models[task] = keras2ipfs(api, model)
 
     with open(f"{Path.home()}/.openmined/models.json", "w") as model_file:
         json.dump(models, model_file)
 
 
-def best_keras_model_for_task(task, return_model=False):
+def best_keras_model_for_task(api, task, return_model=False):
     if not os.path.exists(f'{Path.home()}/.openmined/models.json'):
         return None
 
@@ -55,7 +52,7 @@ def best_keras_model_for_task(task, return_model=False):
         models = json.loads(model_file.read())
         if task in models.keys():
             if return_model:
-                return ipfs2keras(models[task])
+                return ipfs2keras(api, models[task])
             else:
                 return models[task]
 

--- a/grid/lib/output_pipe.py
+++ b/grid/lib/output_pipe.py
@@ -1,5 +1,5 @@
 import keras
-from . import utils, keras_utils
+from . import keras_utils
 from time import time
 
 
@@ -14,7 +14,8 @@ class OutputPipe(keras.callbacks.Callback):
     Or, this class can be used to quit training if a client tells you to.
     """
 
-    def __init__(self, id, publisher, channel, epochs, model_addr, model, email):
+    def __init__(self, api, id, publisher, channel, epochs, model_addr, model, email):
+        self.api = api
         self.id = id
         self.publisher = publisher
         self.channel = channel
@@ -29,7 +30,6 @@ class OutputPipe(keras.callbacks.Callback):
         self.startTime = time()
 
     def on_epoch_end(self, epoch, logs={}):
-        acc = logs.get('acc')
         loss = logs.get('loss')
 
         spec = {}
@@ -48,7 +48,7 @@ class OutputPipe(keras.callbacks.Callback):
     def on_train_end(self, logs={}):
         spec = {}
         spec['type'] = 'transact'
-        spec['model_addr'] = keras_utils.keras2ipfs(self.model)
+        spec['model_addr'] = keras_utils.keras2ipfs(self.api, self.model)
         spec['eval_loss'] = logs.get('loss')
         spec['parent_model'] = self.model_addr
         spec['worker_id'] = self.id

--- a/grid/services/fit_worker.py
+++ b/grid/services/fit_worker.py
@@ -1,4 +1,4 @@
-from ..lib import strings, utils, output_pipe, keras_utils
+from ..lib import utils, output_pipe, keras_utils
 from .. import channels
 import json
 import threading
@@ -44,7 +44,7 @@ class FitWorkerService(BaseService):
         """
 
         # loads keras model from ipfs
-        model = keras_utils.ipfs2keras(decoded['model_addr'])
+        model = keras_utils.ipfs2keras(self.api, decoded['model_addr'])
 
         # gets dataset from ipfs
         try:
@@ -62,6 +62,7 @@ class FitWorkerService(BaseService):
         # https://keras.io/callbacks/
         # See `OutputPipe` for more info.
         self.worker.learner_callback = output_pipe.OutputPipe(
+            api=self.worker.api,
             id=self.worker.id,
             publisher=self.worker.publish,
             channel=train_channel,

--- a/grid/workers/anchor.py
+++ b/grid/workers/anchor.py
@@ -1,5 +1,4 @@
 from . import base_worker
-from .. import channels
 from ..lib import strings
 
 from ..services.passively_broadcast_membership import PassivelyBroadcastMembershipService
@@ -8,9 +7,7 @@ from ..services.listen_for_openmined_nodes import ListenForOpenMinedNodesService
 class GridAnchor(base_worker.GridWorker):
 
 	def __init__(self):
-		super().__init__()
-
-		self.node_type = "ANCHOR"
+		super().__init__('ANCHOR')
 
 		# prints a picture of an anchor :)
 		print(strings.anchor)
@@ -23,5 +20,3 @@ class GridAnchor(base_worker.GridWorker):
 		# just lets the network know its a member of the openmined network
 		self.services['passively_broadcast_membership'] = PassivelyBroadcastMembershipService(self)
 
-		
-		

--- a/grid/workers/compute.py
+++ b/grid/workers/compute.py
@@ -16,9 +16,7 @@ class GridCompute(base_worker.GridWorker):
     """
 
     def __init__(self):
-        super().__init__()
-
-        self.node_type = "COMPUTE"
+        super().__init__('COMPUTE')
 
         # prints a pretty picture of a Computer
         print(strings.compute)


### PR DESCRIPTION
Previously, if you were running a worker and a client on the same ipfs
node they could not talk as their unique identifiers were derived from
the same source (ipfs peer id).

To support this use case (e.g. local development) out of the box, I've
appended the node type to the beginning of the peer id.

At the same time, I refactored some components of utils to receive a
`ipfsapi` object instead of retrieving their own and cleaned up some
pep8 errors.

In future, we may want to move towards abstracting ipfs away from the
core grid codebase for cleaner abstractions and testing purposes.