### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ubuntu LTS 16.04:
 
 ```
 apt install python3
-apt install python3-pip3
+apt install python-pip3
 ```
 
 # Installing Grid


### PR DESCRIPTION
Previously instructed user to install pip3 via the package `python3-pip3` for Ubuntu.  The actual package is `python3-pip`.