### PR TITLE
Solve socketio dependency problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ black
 requests
 pre-commit
 pytest
+python-socketio>=4.0.3
 websocket_client
 websockets>=7.0
 Flask


### PR DESCRIPTION
I think I've found the problem of #222!
Apparently there is a confusion about the name of the packages. Although it is imported as socketio, the name of the package to be installed is python-socketio.
There is a discussion of this problem [here](https://github.com/miguelgrinberg/python-socketio/issues/190)
