### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ black
 coverage
 Flask
 flask_socketio
+numpy>=1.14.0
 pre-commit
 pytest
 python-socketio>=4.0.3


### PR DESCRIPTION
Fix: `: numpy 1.13.3 is installed but numpy>=1.14.0 is required by {'tf-encrypted'}` error in Travis build.